### PR TITLE
Update colab-requirements.txt: folium==0.2.1

### DIFF
--- a/Custom Model Examples/Boston Housing/colab-requirements.txt
+++ b/Custom Model Examples/Boston Housing/colab-requirements.txt
@@ -1,4 +1,5 @@
 datarobot==2.21.3
 datarobot-drum==1.3.0
+folium==0.2.1
 PyYAML==5.3.1
 xgboost==1.2.1


### PR DESCRIPTION
Just ran the Boston Housing/Main_Script.ipynb notebook today in colab and was prompted that folium-0.2.1 was required instead of 0.8.3.

I installed 0.2.1 and the notebook ran fine, but I don't know whether it would have still executed without the change.