### PR TITLE
Fix the errors in the DRUM introduction notebook linked from "Introducing DRUM" tutorial

### DIFF
--- a/custom_inference/python/boston_housing/Main_Script.ipynb
+++ b/custom_inference/python/boston_housing/Main_Script.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/datarobot-community/mlops-examples/blob/master/Custom%20Model%20Examples/Boston%20Housing/Main_Script.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/datarobot-community/custom-models/blob/master/custom_inference/python/boston_housing/Main_Script.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/custom_inference/python/boston_housing/Main_Script.ipynb
+++ b/custom_inference/python/boston_housing/Main_Script.ipynb
@@ -361,7 +361,7 @@
     }
    ],
    "source": [
-    "!drum score --code-dir /content/mlops-examples/custom_inference/python/boston_housing/src/custom_model --input /content/mlops-examples/'Custom Model Examples'/'Boston Housing'/data/boston_housing_inference.csv --output /content/mlops-examples/'Custom Model Examples'/'Boston Housing'/data/predictions.csv --target-type regression"
+    "!drum score --code-dir /content/mlops-examples/custom_inference/python/boston_housing/src/custom_model --input /content/mlops-examples/custom_inference/python/boston_housing/data/boston_housing_inference.csv --output /content/mlops-examples/'Custom Model Examples'/'Boston Housing'/data/predictions.csv --target-type regression"
    ]
   },
   {
@@ -742,7 +742,7 @@
     }
    ],
    "source": [
-    "!drum score --code-dir /content/mlops-examples/custom_inference/python/boston_housing/src/other_models/h2o_mojo/regression --input /content/mlops-examples/'Custom Model Examples'/'Boston Housing'/data/boston_housing_inference.csv --target-type regression\n"
+    "!drum score --code-dir /content/mlops-examples/custom_inference/python/boston_housing/src/other_models/h2o_mojo/regression --input /content/mlops-examples/custom_inference/python/boston_housing/data/boston_housing_inference.csv --target-type regression\n"
    ]
   },
   {
@@ -837,7 +837,7 @@
     }
    ],
    "source": [
-    "!drum score --code-dir /content/mlops-examples/custom_inference/python/boston_housing/src/other_models/python3_keras_joblib --input /content/mlops-examples/'Custom Model Examples'/'Boston Housing'/data/boston_housing_inference.csv --target-type regression\n"
+    "!drum score --code-dir /content/mlops-examples/custom_inference/python/boston_housing/src/other_models/python3_keras_joblib --input /content/mlops-examples/custom_inference/python/boston_housing/data/boston_housing_inference.csv --target-type regression\n"
    ]
   },
   {
@@ -883,7 +883,7 @@
     }
    ],
    "source": [
-    "!drum score --code-dir /content/mlops-examples/custom_inference/python/boston_housing/src/other_models/python3_xgboost --input /content/mlops-examples/'Custom Model Examples'/'Boston Housing'/data/boston_housing_inference.csv --target-type regression\n"
+    "!drum score --code-dir /content/mlops-examples/custom_inference/python/boston_housing/src/other_models/python3_xgboost --input /content/mlops-examples/custom_inference/python/boston_housing/data/boston_housing_inference.csv --target-type regression\n"
    ]
   },
   {
@@ -924,7 +924,7 @@
     }
    ],
    "source": [
-    "!drum score --code-dir /content/mlops-examples/custom_inference/python/boston_housing/src/other_models/dr_codegen --input /content/mlops-examples/'Custom Model Examples'/'Boston Housing'/data/boston_housing_inference.csv --target-type regression\n"
+    "!drum score --code-dir /content/mlops-examples/custom_inference/python/boston_housing/src/other_models/dr_codegen --input /content/mlops-examples/custom_inference/python/boston_housing/data/boston_housing_inference.csv --target-type regression\n"
    ]
   },
   {
@@ -1124,7 +1124,7 @@
    "outputs": [],
    "source": [
     "DEPLOYMENT_NAME=\"Boston Housing Prices PGH Data Science Meetup\"\n",
-    "TRAINING_DATA = '/content/mlops-examples/Custom Model Examples/Boston Housing/data/boston_housing.csv''"
+    "TRAINING_DATA = '/content/mlops-examples/custom_inference/python/boston_housing/data/boston_housing.csv''"
    ]
   },
   {

--- a/custom_inference/python/boston_housing/Main_Script.ipynb
+++ b/custom_inference/python/boston_housing/Main_Script.ipynb
@@ -1097,7 +1097,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install /content/datarobot-mlops-*/lib/datarobot_mlops-*.whl -q"
+    "!pip install /content/datarobot_mlops_package-*/lib/datarobot*.whl -q"
    ]
   },
   {

--- a/custom_inference/python/boston_housing/Main_Script.ipynb
+++ b/custom_inference/python/boston_housing/Main_Script.ipynb
@@ -963,7 +963,7 @@
    },
    "outputs": [],
    "source": [
-    "token = \"token\"\n",
+    "token = \"YOUR_DATAROBOT_API_KEY\"\n",
     "endpoint = \"https://app2.datarobot.com\"\n",
     "## connect to DataRobot platform with python client. \n",
     "client = dr.Client(token, \"{}/api/v2\".format(endpoint))\n",

--- a/custom_inference/python/boston_housing/Main_Script.ipynb
+++ b/custom_inference/python/boston_housing/Main_Script.ipynb
@@ -1124,7 +1124,7 @@
    "outputs": [],
    "source": [
     "DEPLOYMENT_NAME=\"Boston Housing Prices PGH Data Science Meetup\"\n",
-    "TRAINING_DATA = '/content/mlops-examples/custom_inference/python/boston_housing/data/boston_housing.csv''"
+    "TRAINING_DATA = '/content/mlops-examples/custom_inference/python/boston_housing/data/boston_housing.csv'"
    ]
   },
   {


### PR DESCRIPTION
Hello DataRobot! I have a few fixes for the notebook that's linked from the [Introducing DRUM tutorial](https://community.datarobot.com/t5/knowledge-base/introducing-drum/ta-p/9703). 

I implemented the changes after trying to follow the tutorial and encountering some errors. I made sure that my changes fixes the cells by running the notebook on Google Colab. 

In addition, the tutorial post should be changed to reflect the structural changes in your `custom_models` repo: The link in the sentence that says "You can test out this workflow by using the code and Jupyter notebook provided here.” is broken. It should point to [the correct link.](https://github.com/datarobot-community/custom-models/blob/master/custom_inference/python/boston_housing/Main_Script.ipynb)

Happy to communicate under this PR and hear your thoughts, cheers!