### PR TITLE
Mel/keras tf resolution

### DIFF
--- a/custom_inference/python/mnist/drum/custom.py
+++ b/custom_inference/python/mnist/drum/custom.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 from tensorflow import keras
 from tensorflow.keras import layers
-from keras.models import Sequential
+from tensorflow.keras.models import Sequential
 import os
 import io
 from io import StringIO

--- a/custom_inference/python/mnist/drum/requirements.txt
+++ b/custom_inference/python/mnist/drum/requirements.txt
@@ -1,3 +1,2 @@
 numpy==1.19.2
-keras==2.4.3
 tensorflow==2.4.0


### PR DESCRIPTION
**Motivation:** Installing the standalone keras package seemed to result in a collision with the keras embedded in tensorflow.  This resulted in the error: `module 'tensorflow.compat.v2.__internal__' has no attribute 'tf2'`.  This has been a problem for at least a few months: https://datarobot.slack.com/archives/CNPG5975J/p1627575911085100. 

**Solution:** Removing keras from the requirements.txt file and adjusting the relevant import statement in custom.py has resolved this issue.
